### PR TITLE
added a assertion check for vcm in test_init_2d of init_make_random_sphere test which I forgot in prev. Pull request

### DIFF
--- a/hoomd/mpcd/test-py/init_make_random_sphere_test.py
+++ b/hoomd/mpcd/test-py/init_make_random_sphere_test.py
@@ -64,6 +64,10 @@ class mpcd_snapshot(unittest.TestCase):
         if hoomd.comm.get_rank() == 0:
             r = np.linalg.norm(snap.particles.position, axis=1)
 
+            # center of mass velocity should be zero
+            vcm = np.mean(snap.particles.velocity, axis=0)
+            self.assertTrue(np.allclose(vcm, [0, 0, 0]))
+
             # z components should be zero in 2d
             self.assertTrue(np.allclose(snap.particles.position[:, 2], 0))
             self.assertTrue(np.allclose(snap.particles.velocity[:, 2], 0))


### PR DESCRIPTION
This PR is to add small assertion check on vcm of solvent particles in unittest - init_make_random_sphere_test which I forgot to add in the prev. Pull request
```

```

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
